### PR TITLE
remove plone.formwidget.datetime dependency

### DIFF
--- a/plone/formwidget/recurrence/tests/test_z3cwidget.py
+++ b/plone/formwidget/recurrence/tests/test_z3cwidget.py
@@ -1,5 +1,5 @@
 from OFS.SimpleItem import SimpleItem
-from plone.formwidget.datetime.z3cform.widget import DateFieldWidget
+from plone.app.z3cform.widget import DateFieldWidget
 from plone.formwidget.recurrence.tests.base import IntegrationTestCase
 from plone.formwidget.recurrence.z3cform.widget import RecurrenceFieldWidget
 from z3c.form import form, field

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
             'Products.ATContentTypes',
             'Products.GenericSetup',
             'plone.app.testing',
-            'plone.formwidget.datetime',
+            'plone.app.z3cform',
             'unittest2',
             'z3c.form[test]',
         ]


### PR DESCRIPTION
remove plone.formwidget.datetime dependency so plone.app.widgets can be used instead.
