### PR TITLE
Fix error on ie9 when rednering recurrence widget inside an overlay.

### DIFF
--- a/plone/formwidget/recurrence/z3cform/recurrence_input.pt
+++ b/plone/formwidget/recurrence/z3cform/recurrence_input.pt
@@ -11,12 +11,14 @@
 <tal:block condition="python:view.read_only() == 'true'">
   <span style="display:none;" tal:attributes="id string:${view/id}-start;name string:${view/name}-start" tal:content="view/get_start_date"/>
 </tal:block>
-<script type="text/javascript" defer
-    tal:content="string: jQuery(document).ready(function() {
-                             jQuery.tools.recurrenceinput.localize('${request/LANGUAGE}', ${view/translation});
-                             jQuery('#${view/id}').recurrenceinput(
-                                 ${view/js_recurrenceinput_params}
-                             );
-                         });">
+<script type="text/javascript"
+    tal:content="string: if (typeof(jQuery) !== 'undefined') {
+                           jQuery(document).ready(function() {
+                               jQuery.tools.recurrenceinput.localize('${request/LANGUAGE}', ${view/translation});
+                               jQuery('#${view/id}').recurrenceinput(
+                                   ${view/js_recurrenceinput_params}
+                               );
+                           });
+                         };">
 </script>
 </html>


### PR DESCRIPTION
This PR attempts to fix the following two problems:
- The widget cannot be rendered on ie9 inside an overlay: On ie9 jquery internal method `$.buildFragment` crashes when the `defer` attribute is set. This method is used by `plone.app.querytools` when loading into an overlay. (`defer` should only be used, when there is an external script, according to http://www.w3schools.com/tags/att_script_defer.asp)
- Subsequent-error, when removing `defer`: On ie9 js-code loaded into an overlay seems to be executed twice, the first time the current page's globals are not available.
