### PR TITLE
Recurrence widget not shown in Plone 4.3/Archetypes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.2.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix typo in the template of the AT widget, which prevented it from loading.
+  [mitakas]
 
 
 1.2.5 (2014-07-22)

--- a/plone/formwidget/recurrence/at/widget.pt
+++ b/plone/formwidget/recurrence/at/widget.pt
@@ -27,7 +27,7 @@
           <!-- Make the text area a recurrenceinput -->
           <script type="text/javascript"
               tal:content="string:
-              string: if (typeof jQuery !== 'undefined') {
+              if (typeof jQuery !== 'undefined') {
                 jQuery(document).ready(function() {
                   jQuery.tools.recurrenceinput.localize('${request/LANGUAGE}', ${widget/@@recurrence_widget/translation});
                   jQuery('.ArchetypesRecurrenceWidget textarea').recurrenceinput(


### PR DESCRIPTION
The widget was not shown because of an error in the template ("string:" appeares twice).