### PR TITLE
No need for unittest2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove unittest2 dependency.
+  [gforcada]
 
 
 2.0.1 (2015-06-05)

--- a/plone/formwidget/recurrence/tests/base.py
+++ b/plone/formwidget/recurrence/tests/base.py
@@ -7,7 +7,7 @@ from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
 from zope.interface import Interface
 
-import unittest2 as unittest
+import unittest
 
 
 PLONE5 = getFSVersionTuple()[0] >= 5

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
             'plone.app.testing',
             'plone.app.z3cform',
             'plone.formwidget.recurrence[archetypes, z3cform]',
-            'unittest2',
         ]
     ),
     entry_points="""


### PR DESCRIPTION
Since python 2.7 unittest2 was already merged with unittest.