### PR TITLE
Fix index out of range bug for current batch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Fixes:
 
 - Removed unittest2 dependency.
   [gforcada]
+- Fix list index out of range at pagination.
+  [julianhandl]
 
 
 2.0.1 (2015-06-05)

--- a/plone/formwidget/recurrence/browser/json_recurrence.py
+++ b/plone/formwidget/recurrence/browser/json_recurrence.py
@@ -171,6 +171,10 @@ class RecurrenceView(BrowserView):
             ((x * batch_size) + 1, (x + 1) * batch_size)
             for x in range(first_batch, last_batch + 1)
         ]
+        # cur_batch must be set relative to first_batch as the batches array
+        # is cut down, but the cur_batch variable is not. With this we prevent
+        # a list index out of range error
+        cur_batch = cur_batch - first_batch
         # correct number of occurrences in current batch
         (cur_batch_start, cur_batch_end) = batches[cur_batch]
         if cur_batch_end > len(occurrences):


### PR DESCRIPTION
As reported in Bug #16 we get an "list index out of range" error when using the pagination. I fixed this bug by setting the cur_batch variable relative to the first_batch variable. The batches array is created relative to the first_batch variable but the cur_batch variable is set absolute to the whole pagination.