### PR TITLE
Do not add charset to application/x-www-form-urlencoded header.

### DIFF
--- a/news/844.bugfix
+++ b/news/844.bugfix
@@ -1,0 +1,3 @@
+Do not add charset to application/x-www-form-urlencoded header.
+Adding a charset to this Content-Type is illegal according to the definition, and fails with Zope master.
+[maurits]

--- a/plone/formwidget/recurrence/tests/test_z3cwidget.py
+++ b/plone/formwidget/recurrence/tests/test_z3cwidget.py
@@ -52,7 +52,7 @@ class Z3CWidgetTestCase(IntegrationTestCase):
         pat_options = json.loads(self.widget.get_pattern_options())
         self.assertEqual(
             {
-                "ajaxContentType": "application/x-www-form-urlencoded; charset=UTF-8",
+                "ajaxContentType": "application/x-www-form-urlencoded",
                 "ajaxURL": "http://nohost/plone/@@json_recurrence",
                 "firstDay": 7,
                 "hasRepeatForeverButton": True,

--- a/plone/formwidget/recurrence/z3cform/widget.py
+++ b/plone/formwidget/recurrence/z3cform/widget.py
@@ -57,7 +57,7 @@ class RecurrenceWidget(TextAreaWidget):
         portal = getToolByName(getSite(), "portal_url").getPortalObject()
         ajax_url = portal.absolute_url() + "/@@json_recurrence"
         conf = dict(
-            ajaxContentType="application/x-www-form-urlencoded; charset=UTF-8",
+            ajaxContentType="application/x-www-form-urlencoded",
             ajaxURL=ajax_url,
             firstDay=self.first_day(),
             hasRepeatForeverButton=self.show_repeat_forever,


### PR DESCRIPTION
Adding a charset to this Content-Type is illegal according to the definition, and fails with Zope master. See https://github.com/plone/buildout.coredev/pull/844#issuecomment-1461620409

In our case, when you click to add a recurrence, you get a dialog box saying 'error' because the call to `@@json_recurrence` failed.